### PR TITLE
Support json_bytes option as JSON-encoded bytes

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -315,9 +315,13 @@ func (r *Registry) processMessage(message *protoparserparser.Message, allResolve
 					Type:       *fieldType,
 					JsonName:   findJSONName(field.FieldOptions),
 					JSONString: isJSONString(field.FieldOptions),
+					JSONBytes: isJSONBytes(field.FieldOptions),
 				}
 				if f.JSONString && (f.Type.Kind != schema.KindWrapper || f.Type.WrapperType != schema.WrapperStringValue) {
 					return nil, fmt.Errorf("expected %s type at %s for json_string, got %+v", schema.WrapperStringValue, f.Name, f.Type)
+				}
+				if f.JSONBytes && (f.Type.Kind != schema.KindPrimitive || f.Type.PrimitiveType != schema.TypeBytes) {
+					return nil, fmt.Errorf("expected %s type at %s for %s, got %+v", schema.TypeBytes, f.Name, optionJSONBytes, f.Type)
 				}
 				oneOfFields = append(oneOfFields, f)
 			}
@@ -376,9 +380,13 @@ func (r *Registry) processField(field *protoparserparser.Field, resolvedEntities
 		Type:       *fieldType,
 		JsonName:   findJSONName(field.FieldOptions),
 		JSONString: isJSONString(field.FieldOptions),
+		JSONBytes: isJSONBytes(field.FieldOptions),
 	}
 	if f.JSONString && (f.Type.Kind != schema.KindWrapper || f.Type.WrapperType != schema.WrapperStringValue) {
 		return nil, fmt.Errorf("expected %s type at %s for json_string, got %+v", schema.WrapperStringValue, f.Name, f.Type)
+	}
+	if f.JSONBytes && (f.Type.Kind != schema.KindPrimitive || f.Type.PrimitiveType != schema.TypeBytes) {
+		return nil, fmt.Errorf("expected %s type at %s for %s, got %+v", schema.TypeBytes, f.Name, optionJSONBytes, f.Type)
 	}
 	return f, nil
 }
@@ -413,6 +421,17 @@ func (r *Registry) processMapField(field *protoparserparser.MapField, resolvedEn
 func isJSONString(opts []*protoparserparser.FieldOption) bool {
 	for _, opt := range opts {
 		if opt.OptionName == "json_string" {
+			return true
+		}
+	}
+	return false
+}
+
+// isJSONBytes reports whether a field carries the json_bytes option. Such
+// fields must be `bytes` on the wire and carry a JSON-encoded value.
+func isJSONBytes(opts []*protoparserparser.FieldOption) bool {
+	for _, opt := range opts {
+		if strings.TrimSpace(opt.OptionName) == optionJSONBytes {
 			return true
 		}
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/anirudhraja/protolite/schema"
@@ -1166,4 +1167,94 @@ func TestGetEnum_AmbiguityDetection(t *testing.T) {
 			}
 		}
 	})
+}
+
+func loadProto(t *testing.T, content string) (*Registry, string) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "jsonbytes_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	protoPath := filepath.Join(tmpDir, "test.proto")
+	if err := os.WriteFile(protoPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Open(protoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { file.Close() })
+
+	r := NewRegistry([]string{""})
+	return r, protoPath
+}
+
+func TestJSONBytes_ParsedOnBytesField(t *testing.T) {
+	content := `syntax = "proto3";
+package test.jsonbytes;
+
+message Holder {
+  bytes session = 1 [json_bytes = true];
+  string name = 2;
+}
+`
+	r, protoPath := loadProto(t, content)
+	file, err := os.Open(protoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if err := r.LoadSchema(file, protoPath); err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+
+	msg, err := r.GetMessage("test.jsonbytes.Holder")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+
+	var session, name bool
+	for _, f := range msg.Fields {
+		switch f.Name {
+		case "session":
+			session = true
+			if !f.JSONBytes {
+				t.Errorf("session field: JSONBytes = false, want true")
+			}
+		case "name":
+			name = true
+			if f.JSONBytes {
+				t.Errorf("name field: JSONBytes = true, want false")
+			}
+		}
+	}
+	if !session || !name {
+		t.Fatalf("expected to find both fields, got session=%v name=%v", session, name)
+	}
+}
+
+func TestJSONBytes_RejectedOnNonBytesField(t *testing.T) {
+	content := `syntax = "proto3";
+package test.jsonbytes;
+
+message Bad {
+  string session = 1 [json_bytes = true];
+}
+`
+	r, protoPath := loadProto(t, content)
+	file, err := os.Open(protoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	err = r.LoadSchema(file, protoPath)
+	if err == nil {
+		t.Fatalf("expected error for json_bytes on non-bytes field, got nil")
+	}
+	if !strings.Contains(err.Error(), "json_bytes") {
+		t.Errorf("error should mention json_bytes, got: %v", err)
+	}
 }

--- a/registry/utils.go
+++ b/registry/utils.go
@@ -18,6 +18,7 @@ const (
 	optionWrapper        = "wrapper"
 	optionShowNull       = "show_null"
 	optionTrackNull      = "track_null"
+	optionJSONBytes      = "json_bytes"
 )
 
 // getAllProtoInfoFromReader uses DFS to fetch proto info starting from a reader, with dependent protos loaded from files

--- a/schema/types.go
+++ b/schema/types.go
@@ -47,6 +47,7 @@ type Field struct {
 	JsonName     string     `json:"json_name"`     // JSON field name
 	OneofIndex   int32      `json:"oneof_index"`   // oneof group index (-1 if not in oneof)
 	JSONString   bool       `json:"json_string"`   // when set raw json string is used to transport gql scalars on wire.
+	JSONBytes    bool       `json:"json_bytes"`    // when set (via the json_bytes field option) a bytes field carries a JSON-encoded value: json.Marshal on encode, json.Unmarshal on decode.
 }
 
 // Oneof represents a oneof group

--- a/wire/decoder.go
+++ b/wire/decoder.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -299,7 +300,20 @@ func (d *Decoder) DecodeTypedField(field *schema.Field, wireType WireType) (inte
 	fieldType := field.Type
 	switch fieldType.Kind {
 	case schema.KindPrimitive:
-		return d.decodePrimitive(field, wireType)
+		value, isPacked, err := d.decodePrimitive(field, wireType)
+		if err != nil {
+			return nil, false, err
+		}
+		// A bytes field annotated with json_bytes carries a
+		// JSON-encoded value on the wire; decode it back into a Go value.
+		if field.JSONBytes && !isPacked {
+			decoded, err := decodeJSONBytes(value)
+			if err != nil {
+				return nil, false, fmt.Errorf("field %s: %w", field.Name, err)
+			}
+			return decoded, false, nil
+		}
+		return value, isPacked, nil
 	case schema.KindMessage:
 		md := NewMessageDecoder(d)
 		value, err := md.DecodeMessage(fieldType.MessageType)
@@ -368,6 +382,26 @@ func (d *Decoder) DecodeTypedField(field *schema.Field, wireType WireType) (inte
 		value, err := d.decodeRawValue(wireType)
 		return value, false, err
 	}
+}
+
+// decodeJSONBytes interprets the raw bytes of a json_bytes field as a JSON
+// document and decodes it into a Go value. Numbers are preserved as
+// json.Number to match the rest of the library and avoid precision loss.
+func decodeJSONBytes(value interface{}) (interface{}, error) {
+	raw, ok := value.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("json_bytes field expected bytes, got %T", value)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var out interface{}
+	if err := dec.Decode(&out); err != nil {
+		return nil, fmt.Errorf("unmarshal json_bytes json: %w", err)
+	}
+	return out, nil
 }
 
 // decodePrimitive decodes a primitive type using the appropriate decoder

--- a/wire/jsonbytes_test.go
+++ b/wire/jsonbytes_test.go
@@ -1,0 +1,144 @@
+package wire
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/anirudhraja/protolite/schema"
+)
+
+// jsonBytesMessage returns a message with a single bytes field that is
+// annotated with json_bytes, i.e. it carries a JSON-encoded value
+// on the wire (the pattern used for @thrift GraphQL scalars).
+func jsonBytesMessage() *schema.Message {
+	return &schema.Message{
+		Name: "ThriftScalarHolder",
+		Fields: []*schema.Field{
+			{
+				Name:       "session",
+				Number:     1,
+				Label:      schema.LabelOptional,
+				JSONBytes:  true,
+				Type: schema.FieldType{
+					Kind:          schema.KindPrimitive,
+					PrimitiveType: schema.TypeBytes,
+				},
+			},
+		},
+	}
+}
+
+func TestJSONBytes_RoundTrip(t *testing.T) {
+	msg := jsonBytesMessage()
+
+	session := map[string]interface{}{
+		"uuid":  "dummy-uuid-abc",
+		"state": "ACTIVE",
+		"id":    "dummy-order-123",
+	}
+	data := map[string]interface{}{"session": session}
+
+	encoded, err := EncodeMessage(data, msg, nil)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	// The field must be length-delimited (wire type 2). This is what the
+	// gateway's protolite decoder previously choked on when the value was a
+	// nested wrapper message rather than a flat JSON-bytes scalar.
+	_, wireType := ParseTag(Tag(encoded[0]))
+	if wireType != WireBytes {
+		t.Fatalf("expected wire type %d (bytes), got %d", WireBytes, wireType)
+	}
+
+	decodedI, err := DecodeMessage(encoded, msg, nil)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	decoded, ok := decodedI.(map[string]interface{})
+	if !ok {
+		t.Fatalf("decoded is %T, want map[string]interface{}", decodedI)
+	}
+
+	got, ok := decoded["session"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("session decoded as %T, want map[string]interface{}", decoded["session"])
+	}
+	if !reflect.DeepEqual(got, session) {
+		t.Errorf("round-trip mismatch:\n got:  %#v\n want: %#v", got, session)
+	}
+}
+
+// TestJSONBytes_DecodesRawJSONBytes mimics the real gateway scenario: a peer
+// service (mirror) emits a plain bytes field whose contents are json.Marshal of
+// the thrift model. Protolite must json.Unmarshal it back into a structured
+// value rather than surfacing the raw base64 bytes.
+func TestJSONBytes_DecodesRawJSONBytes(t *testing.T) {
+	msg := jsonBytesMessage()
+
+	payload := map[string]interface{}{"uuid": "abc", "nested": map[string]interface{}{"k": "v"}}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Hand-build the wire bytes: tag for field 1 (bytes) + length-delimited JSON.
+	enc := NewEncoder()
+	NewVarintEncoder(enc).EncodeVarint(uint64(MakeTag(1, WireBytes)))
+	NewBytesEncoder(enc).EncodeBytes(raw)
+
+	decodedI, err := DecodeMessage(enc.Bytes(), msg, nil)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	decoded := decodedI.(map[string]interface{})
+	got, ok := decoded["session"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("session decoded as %T, want map[string]interface{}", decoded["session"])
+	}
+	if !reflect.DeepEqual(got, payload) {
+		t.Errorf("mismatch:\n got:  %#v\n want: %#v", got, payload)
+	}
+}
+
+func TestJSONBytes_Repeated(t *testing.T) {
+	msg := &schema.Message{
+		Name: "RepeatedHolder",
+		Fields: []*schema.Field{
+			{
+				Name:       "sessions",
+				Number:     1,
+				Label:      schema.LabelRepeated,
+				JSONBytes:  true,
+				Type: schema.FieldType{
+					Kind:          schema.KindPrimitive,
+					PrimitiveType: schema.TypeBytes,
+				},
+			},
+		},
+	}
+
+	elems := []interface{}{
+		map[string]interface{}{"id": "a"},
+		map[string]interface{}{"id": "b"},
+	}
+	data := map[string]interface{}{"sessions": elems}
+
+	encoded, err := EncodeMessage(data, msg, nil)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decodedI, err := DecodeMessage(encoded, msg, nil)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	decoded := decodedI.(map[string]interface{})
+	got, ok := decoded["sessions"].([]interface{})
+	if !ok {
+		t.Fatalf("sessions decoded as %T, want []interface{}", decoded["sessions"])
+	}
+	if !reflect.DeepEqual(got, elems) {
+		t.Errorf("mismatch:\n got:  %#v\n want: %#v", got, elems)
+	}
+}

--- a/wire/message.go
+++ b/wire/message.go
@@ -204,6 +204,13 @@ func (me *MessageEncoder) encodeFieldValue(value interface{}, field *schema.Fiel
 		b, _ := json.Marshal(value)
 		value = string(b)
 	}
+	if field.JSONBytes {
+		b, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Errorf("marshal %s value for field %s: %w", "json_bytes", field.Name, err)
+		}
+		value = b
+	}
 	switch field.Type.Kind {
 	case schema.KindPrimitive:
 		return me.encodePrimitiveField(value, field.Type.PrimitiveType)
@@ -287,6 +294,18 @@ func (me *MessageEncoder) encodeRepeatedField(value interface{}, field *schema.F
 			b, _ := json.Marshal(slice[i])
 			slice[i] = string(b)
 		}
+	}
+	if field.JSONBytes {
+		// Build a new slice to avoid mutating the caller's input.
+		marshaled := make([]interface{}, len(slice))
+		for i := 0; i < len(slice); i++ {
+			b, err := json.Marshal(slice[i])
+			if err != nil {
+				return fmt.Errorf("marshal %s element for field %s: %w", "json_bytes", field.Name, err)
+			}
+			marshaled[i] = b
+		}
+		slice = marshaled
 	}
 
 	var packed bool


### PR DESCRIPTION
## Summary
- Adds a new `json_bytes` field option: a `bytes` field annotated with `json_bytes = true` is treated as a flat, length-delimited scalar whose payload is JSON — `json.Marshal` on encode, `json.Unmarshal` on decode.
- Mirrors the existing `json_string` option handling and lets schema-based decoding transparently expand `@thrift` GraphQL scalars instead of surfacing raw base64 bytes.
- `schema.Field` gains a `JSONBytes` flag; the registry parses the `json_bytes` option and enforces it only applies to `bytes` fields.
- Encode/decode paths marshal/unmarshal JSON for such fields (including `repeated`) without mutating caller input.

## Test plan
- [ ] `go build ./...`
- [ ] `go test ./registry/ ./wire/` (new registry parse/validation tests + wire round-trip tests, incl. repeated and raw-JSON-bytes decode)
- [ ] `go test ./...` (full suite green)

Made with [Cursor](https://cursor.com)